### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/H2SO4DIP/Happyminning/security/code-scanning/1](https://github.com/H2SO4DIP/Happyminning/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since the workflow only checks out the repository and runs scripts, it likely only needs `contents: read` permissions. This change ensures that the workflow does not inadvertently gain unnecessary write permissions, improving security.

The `permissions` block should be added immediately after the `name` field (line 3) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
